### PR TITLE
Create the `fail` method

### DIFF
--- a/cspecs/cspec.c
+++ b/cspecs/cspec.c
@@ -173,6 +173,16 @@ It**  ITS;
             }                                                                                       \
         }                                                                                           \
 
+    void __fail(String file, Int line, String reason){
+        It* _it = __current_it();
+        _it->is_failure = true;
+        String template = "Failed because: <%s>";
+        int message_size = fprintf(devNull, template, reason);
+        String error = malloc(message_size + 1);
+        sprintf(error, template, reason);
+        _it->shoulds[SHOULD_COUNT++] = __should_create(error, file, line);
+    }
+
     void __should_bool(String file, Int line, Bool actual, Bool negated, Bool expected) {
         char* to_s(Bool p) { return p ? "true" : "false"; }
         __should_boolp(file, line, to_s(actual), negated, to_s(expected));

--- a/cspecs/cspec.h
+++ b/cspecs/cspec.h
@@ -39,6 +39,8 @@
         void __after  (Function function);
         void __before (Function function);
 
+        void __fail(String file, Int line, String reason);
+
         int report(Report);
 
         #define __should_declaration(suffix, type)                                                  \
@@ -75,6 +77,7 @@
 
         #define __should_call(suffix, actual)   __should_##suffix(__FILE__, __LINE__, (actual),
 
+        #define fail(reason)                    __fail(__FILE__, __LINE__, reason)
         #define should_bool(actual)             __should_call(bool  , actual)
         #define should_char(actual)             __should_call(char  , actual)
         #define should_short(actual)            __should_call(short , actual)


### PR DESCRIPTION
```
context (example) {
    describe("Failure") {
        it("shouldFail") {
            fail("That's the test");
        } end
}
```

I don't have a better use case :smile_cat: 