### PR TITLE
avoid use of nested function

### DIFF
--- a/cspecs/cspec.c
+++ b/cspecs/cspec.c
@@ -174,8 +174,9 @@ It**  ITS;
         }                                                                                           \
 
     void __should_bool(String file, Int line, Bool actual, Bool negated, Bool expected) {
-        char* to_s(Bool p) { return p ? "true" : "false"; }
-        __should_boolp(file, line, to_s(actual), negated, to_s(expected));
+        char *actual_s = actual ? "true" : "false";
+        char *expected_s = expected ? "true" : "false";
+        __should_boolp(file, line, actual_s, negated, expected_s);
     }
 
     __should_definition(boolp , String, strcmp(actual, expected) == 0 , "%s");


### PR DESCRIPTION
nested functions are an extension to C implemented by GCC, compilation can fail
when using compilers such as clang or gcc with the -std=C99 flag.