### PR TITLE
Typo in compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ context (example) {
 ### Now, what should I do?
 * Write your C code
 * Write your specs
-* Compile with the `-l`should`` option. For example: `gcc -lcspec cspecExample.c -o cspecExample`
+* Compile with the `-l`should`` option. For example: `gcc -lcspecs cspecExample.c -o cspecExample`
 * Run it on the console: `./cspecExample`
 
 ### What does cspec offer me?


### PR DESCRIPTION
In the section **"Now, what should I do?"** there is a typo in the compile's example.

It says...
```bash
gcc -lcspec cspecExample.c -o cspecExample  # -lcspec
```

...instead of 

```bash
gcc -lcspecs cspecExample.c -o cspecExample  # -lcspecs
```