### PR TITLE
Removing inner helper function to let it compile with LLVM

### DIFF
--- a/cspecs/cspec.c
+++ b/cspecs/cspec.c
@@ -173,9 +173,9 @@ It**  ITS;
             }                                                                                       \
         }                                                                                           \
 
+    char* __to_s(Bool p) { return p ? "true" : "false"; }
     void __should_bool(String file, Int line, Bool actual, Bool negated, Bool expected) {
-        char* to_s(Bool p) { return p ? "true" : "false"; }
-        __should_boolp(file, line, to_s(actual), negated, to_s(expected));
+        __should_boolp(file, line, __to_s(actual), negated, __to_s(expected));
     }
 
     __should_definition(boolp , String, strcmp(actual, expected) == 0 , "%s");


### PR DESCRIPTION
LLVM compiler (which is used by default on `gcc` in OSX) doesn't support inner functions.

I just removed a single inner function usage.

Future work to make this library work on OSX might include changing the system wide installation folder (which should be `/usr/local/bin/` in the latest versions of the OS).