### PR TITLE
build: publish header in CMake project

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -24,7 +24,7 @@ jobs:
       
     # Includes the AsciiDoctor GitHub Pages Action to convert adoc files to html and publish to gh-pages branch
     - name: asciidoctor-ghpages
-      uses: manoelcampos/asciidoctor-ghpages-action@v2.2.0
+      uses: manoelcampos/asciidoctor-ghpages-action@v2.2.4
       with:
         # asciidoctor_params: --attribute=nofooter
         pdf_build: true

--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -5,13 +5,15 @@ name: asciidoctor-ghpages
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # This workflow must run only under mumuki org
+    if: github.repository_owner == 'mumuki'
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -21,6 +21,9 @@ jobs:
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
+    # This workflow must run only under mumuki org
+    if: github.repository_owner == 'mumuki'
+
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ release
 test.c
 example.c
 cspec.wiki
+/.idea/
+/cmake-build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCE_FILES
         cspecs/cspec.c)
 
 add_library(cspecs SHARED ${SOURCE_FILES})
+set_target_properties(cspecs PROPERTIES PUBLIC_HEADER cspecs/cspec.h)
 
 install(TARGETS cspecs
         LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        PUBLIC_HEADER DESTINATION include/cspecs)


### PR DESCRIPTION
With this update, CSpec could be included in a CMake project without any installation by adding these lines to `CMakeLists.txt`:

```cmake
include(ExternalProject)
ExternalProject_Add(cspecs
    GIT_REPOSITORY https://github.com/mumuki/cspec
    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
)

include_directories(${CMAKE_BINARY_DIR}/include)
link_directories(${CMAKE_BINARY_DIR}/lib)
link_libraries(cspecs)
```

resolves #32 