### PR TITLE
build: auto-detect Homebrew GCC on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ context (example) {
 2. `cd cspec`
 3. `make install`
 
+#### macOS
+The cspec DSL relies on GCC nested functions, which Apple Clang (the default `gcc` on macOS) does not support. Install a real GCC via Homebrew:
+
+```
+brew install gcc
+```
+
+The `makefile` auto-detects the newest `gcc-<version>` installed by Homebrew (e.g. `gcc-13`, `gcc-14`, `gcc-15`, ...). You can also override it explicitly with `make CC=gcc-14`.
+
+When building your own specs on macOS, make sure to invoke the same GCC — for example `gcc-15 cspecExample.c -o cspecExample -lcspecs`.
+
 ### Now, what should I do?
 * Write your C code
 * Write your specs

--- a/README_ES.md
+++ b/README_ES.md
@@ -62,6 +62,17 @@ context (ejemplo) {
 2. `cd cspec`
 3. `make install`
 
+#### macOS
+El DSL de cspec usa *nested functions* de GCC, que Apple Clang (el `gcc` por default en macOS) no soporta. Instalá un GCC real con Homebrew:
+
+```
+brew install gcc
+```
+
+El `makefile` detecta automáticamente la última versión de `gcc-<versión>` instalada por Homebrew (por ejemplo `gcc-13`, `gcc-14`, `gcc-15`, ...). También podés forzar uno explícito con `make CC=gcc-14`.
+
+Cuando compiles tus propios specs en macOS, usá el mismo GCC — por ejemplo `gcc-15 cspecEjemplo.c -o cspecEjemplo -lcspecs`.
+
 ### Ahora, ¿qué hago?
 * Escribí el código C que quieras
 * Probalo usando este framework, para eso no te olvides de compilarlo con `-lcspecs`. Por ejemplo: `gcc -lcspec cspecEjemplo.c -o cspecEjemplo`

--- a/makefile
+++ b/makefile
@@ -1,12 +1,25 @@
 RM=rm -rf
+
+UNAME=$(shell uname)
+
+# On macOS the default `gcc` is Apple Clang, which rejects nested functions
+# used by cspec's DSL macros. Auto-detect the newest Homebrew GCC available
+# (gcc-13, gcc-14, gcc-15, ...) unless the user overrides CC explicitly.
+ifeq ($(origin CC),default)
+ifeq ($(UNAME),Darwin)
+CC := $(shell ls -1 /opt/homebrew/bin/gcc-[0-9]* /usr/local/bin/gcc-[0-9]* 2>/dev/null | sort -V | tail -n 1)
+ifeq ($(CC),)
+$(error Homebrew GCC not found. Install it with 'brew install gcc', or set CC explicitly)
+endif
+else
 CC=gcc
+endif
+endif
 
 C_SRCS=$(shell find . -iname "*.c" | tr '\n' ' ')
 H_SRCS=$(shell find . -iname "*.h" | tr '\n' ' ')
 
 OBJS=$(C_SRCS:./%.c=release/%.o)
-
-UNAME=$(shell uname)
 
 ifneq ($(shell id -un),root)
 SUDO=sudo
@@ -19,7 +32,11 @@ release/cspecs:
 	mkdir -p release/cspecs/
 
 release/libcspecs.so: release/cspecs $(OBJS)
+ifeq ($(UNAME), Darwin)
+	$(CC) -shared -install_name /usr/local/lib/libcspecs.so -o "release/libcspecs.so" $(OBJS)
+else
 	$(CC) -shared -o "release/libcspecs.so" $(OBJS)
+endif
 
 release/cspecs/%.o: cspecs/%.c
 	$(CC) -c -fmessage-length=0 -fPIC -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
@@ -37,8 +54,8 @@ clean:
 
 install: all
 ifeq ($(UNAME), Darwin)
-	$(SUDO) cp release/libcspecs.so /usr/lib
-	$(SUDO) ditto $(H_SRCS) /usr/include
+	$(SUDO) cp release/libcspecs.so /usr/local/lib
+	$(SUDO) ditto $(H_SRCS) /usr/local/include
 else
 	$(SUDO) cp -u release/libcspecs.so /usr/lib
 	$(SUDO) cp --parents -u $(H_SRCS) /usr/include


### PR DESCRIPTION
## Summary

- The cspec DSL relies on GCC nested functions, which Apple Clang (the default `gcc` on macOS) does not support. Compiling any specs on a stock Mac fails.
- The `makefile` now auto-detects the newest `gcc-<version>` installed by Homebrew on Darwin (`gcc-13`, `gcc-14`, `gcc-15`, ...) and uses it as `CC`. You can still override with `make CC=gcc-14`.
- Darwin install paths moved to `/usr/local/{lib,include}` to match Homebrew conventions and avoid SIP-protected `/usr`, and `-install_name` is set so the dylib is loadable after install.
- Both READMEs document the `brew install gcc` prerequisite and note that user specs also need to be compiled with the Homebrew GCC.

## Test plan

- [x] `make clean && make` on macOS (Apple Silicon, `gcc-15` from Homebrew) — builds `release/libcspecs.so` as a Mach-O arm64 shared lib.
- [x] End-to-end smoke test: a spec with nested `describe` + `it` compiles against the built library and runs correctly.
- [ ] Verify `make` still works on Linux (unchanged `CC=gcc` path).
- [ ] Verify `make CC=gcc-14` override is honored on macOS.
- [ ] Verify the `brew install gcc` error message fires cleanly on a Mac without any Homebrew GCC installed.